### PR TITLE
Mccalluc/hide facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.5 - in progress
+### Added
+- Added hiddenFilterIds.
+
 ## 0.0.4 - 2019-04-15
 ### Added
 - Allow a non-default `searchUrlPath`.

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -34,9 +34,9 @@
       <a class="my-0 mr-sm-auto p-2 text-dark font-weight-bold"
          href="#">Lorem Ipsum</a>
       <nav class="my-2 my-md-0 mr-md-3">
-        <a class="p-2 text-dark" href="#">Dolor</a>
-        <a class="p-2 text-dark" href="#">Sit</a>
-        <a class="p-2 text-dark" href="#">Amat</a>
+        <a class="p-2 text-dark" href="/?categories[0][0]=Movie">Movie</a>
+        <a class="p-2 text-dark" href="/?categories[0][0]=Series">Series</a>
+        <a class="p-2 text-dark" href="/?categories[0][0]=Episode">Episode</a>
       </nav>
       <a class="btn btn-outline-primary" href="#">Login</a>
     </div>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -57,6 +57,7 @@ hubmapPortalSearch.renderSearch(
     ],
     httpHeaders: {
       'x-bogus-header': 'bogus-value'
-    }
+    },
+    hiddenFilterIds: ['categories']
   }
 );

--- a/src/Search.js
+++ b/src/Search.js
@@ -93,7 +93,6 @@ export default function (props) {
             <ActionBar>
               <ActionBarRow>
                 <SelectedFilters />
-                <ResetFilters />
               </ActionBarRow>
             </ActionBar>
             {debug && (

--- a/src/Search.js
+++ b/src/Search.js
@@ -54,23 +54,6 @@ function makeTableComponent(fields, detailsUrlPrefix, idField) {
   };
 }
 
-function SelectedFilter(props) {
-  // Copy and paste from
-  // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
-  // plus typo corrections.
-  return (
-    <div className={props.bemBlocks.option()
-      .mix(props.bemBlocks.container("item"))
-      .mix(`selected-filter--${props.filterId}`)}>
-      <div className={props.bemBlocks.option("name")}>{props.labelKey}!: {props.labelValue}</div>
-      <div className={props.bemBlocks.option("remove-action")} onClick={props.removeFilter}>x</div>
-    </div>
-  );
-}
-
-function MaskedSelectedFilters(props) {
-  return <SelectedFilters itemComponent={SelectedFilter} />
-}
 
 export default function (props) {
   const {
@@ -81,6 +64,28 @@ export default function (props) {
   } = props;
   const resultFieldsPlusId = [...resultFields, idField];
   const searchkit = new SearchkitManager(apiUrl, { httpHeaders, searchUrlPath });
+
+  function MaskedSelectedFilters(props) {
+    const SelectedFilter = (props) => {
+      const style = hiddenFilterIds.indexOf(props.filterId) === -1
+        ? {} : {display: 'None'};
+      // Copy and paste from
+      // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
+      // plus typo corrections and wrapping div.
+      return (
+        <div
+          style={style}
+          className={props.bemBlocks.option()
+            .mix(props.bemBlocks.container("item"))
+            .mix(`selected-filter--${props.filterId}`)}
+        >
+          <div className={props.bemBlocks.option("name")}>{props.labelKey}: {props.labelValue}</div>
+          <div className={props.bemBlocks.option("remove-action")} onClick={props.removeFilter}>x</div>
+        </div>
+      );
+    }
+    return <SelectedFilters itemComponent={SelectedFilter} />
+  }
 
   const filterElements = filters.map((def) => {
     const Filter = filterTypes[def.type];

--- a/src/Search.js
+++ b/src/Search.js
@@ -65,7 +65,15 @@ export default function (props) {
 
   const filterElements = filters.map((def) => {
     const Filter = filterTypes[def.type];
-    return <Filter {...def.props} />;
+    const style = def.props.id === 'categories'
+      ? {display: 'None'} : {};
+    return (
+      <div style={style}>
+        <Filter
+          {...def.props}
+        />
+      </div>
+    );
   });
 
   return (

--- a/src/Search.js
+++ b/src/Search.js
@@ -4,7 +4,7 @@ import {
   SearchkitManager, SearchkitProvider, SearchBox,
   LayoutResults,
   ActionBar, ActionBarRow, SelectedFilters,
-  ResetFilters, NoHits,
+  NoHits,
   Hits, Layout, LayoutBody, SideBar, Pagination,
 } from 'searchkit'; // eslint-disable-line import/no-duplicates
 
@@ -65,9 +65,9 @@ export default function (props) {
   const resultFieldsPlusId = [...resultFields, idField];
   const searchkit = new SearchkitManager(apiUrl, { httpHeaders, searchUrlPath });
 
-  function MaskedSelectedFilters(props) {
-    const SelectedFilter = (props) => {
-      const style = hiddenFilterIds.indexOf(props.filterId) === -1
+  function MaskedSelectedFilters() {
+    const SelectedFilter = (filterProps) => {
+      const style = hiddenFilterIds.indexOf(filterProps.filterId) === -1
         ? {} : { display: 'None' };
       // Copy and paste from
       // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
@@ -75,12 +75,12 @@ export default function (props) {
       return (
         <div
           style={style}
-          className={props.bemBlocks.option()
-            .mix(props.bemBlocks.container('item'))
-            .mix(`selected-filter--${props.filterId}`)}
+          className={filterProps.bemBlocks.option()
+            .mix(filterProps.bemBlocks.container('item'))
+            .mix(`selected-filter--${filterProps.filterId}`)}
         >
-          <div className={props.bemBlocks.option('name')}>{props.labelKey}: {props.labelValue}</div>
-          <div className={props.bemBlocks.option('remove-action')} onClick={props.removeFilter}>x</div>
+          <div className={filterProps.bemBlocks.option('name')}>{filterProps.labelKey}: {filterProps.labelValue}</div>
+          <div className={filterProps.bemBlocks.option('remove-action')} onClick={filterProps.removeFilter}>x</div>
         </div>
       );
     };

--- a/src/Search.js
+++ b/src/Search.js
@@ -54,6 +54,24 @@ function makeTableComponent(fields, detailsUrlPrefix, idField) {
   };
 }
 
+function SelectedFilter(props) {
+  // Copy and paste from
+  // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
+  // plus typo corrections.
+  return (
+    <div className={props.bemBlocks.option()
+      .mix(props.bemBlocks.container("item"))
+      .mix(`selected-filter--${props.filterId}`)}>
+      <div className={props.bemBlocks.option("name")}>{props.labelKey}!: {props.labelValue}</div>
+      <div className={props.bemBlocks.option("remove-action")} onClick={props.removeFilter}>x</div>
+    </div>
+  );
+}
+
+function MaskedSelectedFilters(props) {
+  return <SelectedFilters itemComponent={SelectedFilter} />
+}
+
 export default function (props) {
   const {
     apiUrl, prefixQueryFields, filters, detailsUrlPrefix,
@@ -92,7 +110,7 @@ export default function (props) {
           <LayoutResults>
             <ActionBar>
               <ActionBarRow>
-                <SelectedFilters />
+                <MaskedSelectedFilters />
               </ActionBarRow>
             </ActionBar>
             {debug && (

--- a/src/Search.js
+++ b/src/Search.js
@@ -72,6 +72,8 @@ export default function (props) {
       // Copy and paste from
       // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
       // plus typo corrections and wrapping div.
+      /* eslint-disable jsx-a11y/click-events-have-key-events */
+      /* eslint-disable jsx-a11y/no-static-element-interactions */
       return (
         <div
           style={style}
@@ -79,10 +81,20 @@ export default function (props) {
             .mix(filterProps.bemBlocks.container('item'))
             .mix(`selected-filter--${filterProps.filterId}`)}
         >
-          <div className={filterProps.bemBlocks.option('name')}>{filterProps.labelKey}: {filterProps.labelValue}</div>
-          <div className={filterProps.bemBlocks.option('remove-action')} onClick={filterProps.removeFilter}>x</div>
+          <div
+            className={filterProps.bemBlocks.option('name')}
+          >
+            {filterProps.labelKey}: {filterProps.labelValue}
+          </div>
+          <div
+            className={filterProps.bemBlocks.option('remove-action')}
+            onClick={filterProps.removeFilter}
+          >
+            x
+          </div>
         </div>
       );
+      /* eslint-enable */
     };
     return <SelectedFilters itemComponent={SelectedFilter} />;
   }
@@ -91,6 +103,7 @@ export default function (props) {
     const Filter = filterTypes[def.type];
     const style = hiddenFilterIds.indexOf(def.props.id) === -1
       ? {} : { display: 'None' };
+    /* eslint-disable react/jsx-props-no-spreading */
     return (
       <div style={style}>
         <Filter
@@ -98,6 +111,7 @@ export default function (props) {
         />
       </div>
     );
+    /* eslint-enable */
   });
 
   return (

--- a/src/Search.js
+++ b/src/Search.js
@@ -63,10 +63,10 @@ export default function (props) {
   const resultFieldsPlusId = [...resultFields, idField];
   const searchkit = new SearchkitManager(apiUrl, { httpHeaders, searchUrlPath });
 
-  const filterElements = filters.map((def) => React.createElement(
-    filterTypes[def.type],
-    def.props,
-  ));
+  const filterElements = filters.map((def) => {
+    const Filter = filterTypes[def.type];
+    return <Filter {...def.props} />;
+  });
 
   return (
     <SearchkitProvider searchkit={searchkit}>

--- a/src/Search.js
+++ b/src/Search.js
@@ -58,6 +58,7 @@ export default function (props) {
   const {
     apiUrl, prefixQueryFields, filters, detailsUrlPrefix,
     idField, resultFields, hitsPerPage, debug, httpHeaders,
+    hiddenFilterIds = [],
     searchUrlPath = '_search',
   } = props;
   const resultFieldsPlusId = [...resultFields, idField];
@@ -65,8 +66,8 @@ export default function (props) {
 
   const filterElements = filters.map((def) => {
     const Filter = filterTypes[def.type];
-    const style = def.props.id === 'categories'
-      ? {display: 'None'} : {};
+    const style = hiddenFilterIds.indexOf(def.props.id) === -1
+      ? {} : {display: 'None'};
     return (
       <div style={style}>
         <Filter

--- a/src/Search.js
+++ b/src/Search.js
@@ -68,7 +68,7 @@ export default function (props) {
   function MaskedSelectedFilters(props) {
     const SelectedFilter = (props) => {
       const style = hiddenFilterIds.indexOf(props.filterId) === -1
-        ? {} : {display: 'None'};
+        ? {} : { display: 'None' };
       // Copy and paste from
       // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
       // plus typo corrections and wrapping div.
@@ -76,21 +76,21 @@ export default function (props) {
         <div
           style={style}
           className={props.bemBlocks.option()
-            .mix(props.bemBlocks.container("item"))
+            .mix(props.bemBlocks.container('item'))
             .mix(`selected-filter--${props.filterId}`)}
         >
-          <div className={props.bemBlocks.option("name")}>{props.labelKey}: {props.labelValue}</div>
-          <div className={props.bemBlocks.option("remove-action")} onClick={props.removeFilter}>x</div>
+          <div className={props.bemBlocks.option('name')}>{props.labelKey}: {props.labelValue}</div>
+          <div className={props.bemBlocks.option('remove-action')} onClick={props.removeFilter}>x</div>
         </div>
       );
-    }
-    return <SelectedFilters itemComponent={SelectedFilter} />
+    };
+    return <SelectedFilters itemComponent={SelectedFilter} />;
   }
 
   const filterElements = filters.map((def) => {
     const Filter = filterTypes[def.type];
     const style = hiddenFilterIds.indexOf(def.props.id) === -1
-      ? {} : {display: 'None'};
+      ? {} : { display: 'None' };
     return (
       <div style={style}>
         <Filter


### PR DESCRIPTION
This is essentially a stop-gap until https://github.com/hubmapconsortium/search-api/issues/38 is available. It lets us remove facets from the ui, but still have them apply to the search. There are  other ways this could be done - I started trying to generate an inline `style` tag, but was having trouble (that I still don't understand) getting the `display:none` to apply where I wanted it to apply.

Review the code, but feedback on the approach also welcome.